### PR TITLE
Bumped package versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "watch": "rollup -c -w"
     },
     "dependencies": {
-        "yonius": "^0.4.2"
+        "yonius": "^0.5.5"
     },
     "devDependencies": {
         "@babel/core": "^7.10.2",
@@ -57,13 +57,13 @@
         "@rollup/plugin-commonjs": "^12.0.0",
         "@rollup/plugin-node-resolve": "^8.0.0",
         "eslint": "^7.1.0",
-        "eslint-config-hive": "^0.3.3",
+        "eslint-config-hive": "^0.3.6",
         "mocha": "^7.2.0",
         "mocha-cli": "^1.0.1",
         "npm-check-updates": "^6.0.1",
         "prettier": "^2.0.5",
         "prettier-config-hive": "^0.1.7",
-        "rollup": "^2.13.0",
+        "rollup": "^2.33.1",
         "rollup-plugin-node-polyfills": "^0.2.1",
         "sort-package-json": "^1.44.0"
     }


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Not properly converting "*/text" type contents which should be automatic after https://github.com/hivesolutions/yonius/pull/18 |
| Decisions | Bumped package versions to consider latest yonius and fix unexpected buffer type object when receiving "html/text" contents in yonius `get`. |
