### PR TITLE
feat: version 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "epir-papyrus-api",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "The EPIR Papyrus API client",
     "keywords": [
         "api",


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | - New version needs to be released so epir-processor can properly use the newest version of yonius and not fail when fetching for an HTML without having to run `text()` [after this fix](https://github.com/hivesolutions/yonius/pull/18). It's been long since EPIR doen't work in remote deployment and in localhost needs link with the up-to-date version of yonius. This PR fixes this.  |

:warning: Please release a new version 0.1.1 after merge this https://www.npmjs.com/package/epir-papyrus-api